### PR TITLE
Преобразование автоматов pt.3

### DIFF
--- a/include/AlphabetSymbol.h
+++ b/include/AlphabetSymbol.h
@@ -2,7 +2,8 @@
 #include <iostream>
 using namespace std;
 
-using alphabet_symbol = char;
+using alphabet_symbol = string;
 alphabet_symbol epsilon();
 bool is_epsilon(alphabet_symbol);
 string to_string(alphabet_symbol);
+alphabet_symbol char_to_alphabet_symbol(char);

--- a/include/objects/FiniteAutomaton.h
+++ b/include/objects/FiniteAutomaton.h
@@ -74,6 +74,8 @@ class FiniteAutomaton : public BaseObject {
 	// недетерминированных переходах (если ветвление содержит eps-переходы, то
 	// eps размечаются как буквы). ДКА не меняется
 	FiniteAutomaton annote() const;
+	// снятие разметки с букв
+	FiniteAutomaton deannote() const;
 	// объединение эквивалентных классов (принимает на вход вектор размера
 	// states.size()) i-й элемент хранит номер класса i-го состояния
 	FiniteAutomaton merge_equivalent_classes(vector<int>) const;

--- a/include/objects/FiniteAutomaton.h
+++ b/include/objects/FiniteAutomaton.h
@@ -70,6 +70,10 @@ class FiniteAutomaton : public BaseObject {
 	FiniteAutomaton add_trap_state() const;
 	// удаление ловушки
 	FiniteAutomaton remove_trap_state() const;
+	// навешивание разметки на все буквы в автомате, стоящие на
+	// недетерминированных переходах (если ветвление содержит eps-переходы, то
+	// eps размечаются как буквы). ДКА не меняется
+	FiniteAutomaton annote() const;
 	// объединение эквивалентных классов (принимает на вход вектор размера
 	// states.size()) i-й элемент хранит номер класса i-го состояния
 	FiniteAutomaton merge_equivalent_classes(vector<int>) const;

--- a/src/AlphabetSymbol.cpp
+++ b/src/AlphabetSymbol.cpp
@@ -1,14 +1,17 @@
 #include "AlphabetSymbol.h"
 
 alphabet_symbol epsilon() {
-	return '\0';
+	return "eps";
 }
+
 bool is_epsilon(alphabet_symbol as) {
 	return as == epsilon();
 }
+
 string to_string(alphabet_symbol as) {
-	if (is_epsilon(as))
-		return "eps";
-	else
-		return string(1, as);
+	return as;
+}
+
+alphabet_symbol char_to_alphabet_symbol(char c) {
+	return string(1, c);
 }

--- a/src/Example.cpp
+++ b/src/Example.cpp
@@ -8,23 +8,23 @@ void Example::determinize() {
 		states.push_back(s);
 	}
 
-	states[0].set_transition(5, 'x');
-	states[0].set_transition(5, 'y');
-	states[0].set_transition(1, '\0');
-	states[1].set_transition(2, '\0');
-	states[1].set_transition(3, '\0');
-	states[1].set_transition(4, '\0');
-	states[3].set_transition(3, 'x');
-	states[4].set_transition(4, 'y');
-	states[4].set_transition(4, 'y');
-	states[5].set_transition(5, 'z');
-	states[5].set_transition(1, '\0');
+	states[0].set_transition(5, "x");
+	states[0].set_transition(5, "y");
+	states[0].set_transition(1, "eps");
+	states[1].set_transition(2, "eps");
+	states[1].set_transition(3, "eps");
+	states[1].set_transition(4, "eps");
+	states[3].set_transition(3, "x");
+	states[4].set_transition(4, "y");
+	states[4].set_transition(4, "y");
+	states[5].set_transition(5, "z");
+	states[5].set_transition(1, "eps");
 
 	states[2].is_terminal = true;
 	states[3].is_terminal = true;
 	states[4].is_terminal = true;
 
-	FiniteAutomaton nfa(0, states, {'x', 'y', 'z'});
+	FiniteAutomaton nfa(0, states, {"x", "y", "z"});
 	cout << nfa.determinize().to_txt();
 }
 
@@ -36,16 +36,16 @@ void Example::remove_eps() {
 		states.push_back(s);
 	}
 
-	states[0].set_transition(0, '0');
-	states[0].set_transition(1, '\0');
-	states[1].set_transition(1, '1');
-	states[1].set_transition(2, '\0');
-	states[2].set_transition(2, '0');
-	states[2].set_transition(2, '1');
+	states[0].set_transition(0, "0");
+	states[0].set_transition(1, "eps");
+	states[1].set_transition(1, "1");
+	states[1].set_transition(2, "eps");
+	states[2].set_transition(2, "0");
+	states[2].set_transition(2, "1");
 
 	states[2].is_terminal = true;
 
-	FiniteAutomaton nfa(0, states, {'0', '1'});
+	FiniteAutomaton nfa(0, states, {"0", "1"});
 	cout << nfa.remove_eps().to_txt();
 }
 
@@ -57,27 +57,27 @@ void Example::minimize() {
 		states.push_back(s);
 	}
 
-	states[0].set_transition(7, '0');
-	states[0].set_transition(1, '1');
-	states[1].set_transition(0, '1');
-	states[1].set_transition(7, '0');
-	states[2].set_transition(4, '0');
-	states[2].set_transition(5, '1');
-	states[3].set_transition(4, '0');
-	states[3].set_transition(5, '1');
-	states[4].set_transition(5, '0');
-	states[4].set_transition(6, '1');
-	states[5].set_transition(5, '0');
-	states[5].set_transition(5, '1');
-	states[6].set_transition(6, '0');
-	states[6].set_transition(5, '1');
-	states[7].set_transition(2, '0');
-	states[7].set_transition(2, '1');
+	states[0].set_transition(7, "0");
+	states[0].set_transition(1, "1");
+	states[1].set_transition(0, "1");
+	states[1].set_transition(7, "0");
+	states[2].set_transition(4, "0");
+	states[2].set_transition(5, "1");
+	states[3].set_transition(4, "0");
+	states[3].set_transition(5, "1");
+	states[4].set_transition(5, "0");
+	states[4].set_transition(6, "1");
+	states[5].set_transition(5, "0");
+	states[5].set_transition(5, "1");
+	states[6].set_transition(6, "0");
+	states[6].set_transition(5, "1");
+	states[7].set_transition(2, "0");
+	states[7].set_transition(2, "1");
 
 	states[5].is_terminal = true;
 	states[6].is_terminal = true;
 
-	FiniteAutomaton nfa(0, states, {'0', '1'});
+	FiniteAutomaton nfa(0, states, {"0", "1"});
 	cout << nfa.minimize().to_txt();
 }
 
@@ -95,26 +95,26 @@ void Example::intersection() {
 		states2.push_back(s);
 	}
 
-	states1[0].set_transition(0, 'b');
-	states1[0].set_transition(1, 'a');
-	states1[1].set_transition(1, 'b');
-	states1[1].set_transition(2, 'a');
-	states1[2].set_transition(2, 'a');
-	states1[2].set_transition(2, 'b');
+	states1[0].set_transition(0, "b");
+	states1[0].set_transition(1, "a");
+	states1[1].set_transition(1, "b");
+	states1[1].set_transition(2, "a");
+	states1[2].set_transition(2, "a");
+	states1[2].set_transition(2, "b");
 
 	states1[1].is_terminal = true;
 
-	states2[0].set_transition(0, 'a');
-	states2[0].set_transition(1, 'b');
-	states2[1].set_transition(1, 'a');
-	states2[1].set_transition(2, 'b');
-	states2[2].set_transition(2, 'a');
-	states2[2].set_transition(2, 'b');
+	states2[0].set_transition(0, "a");
+	states2[0].set_transition(1, "b");
+	states2[1].set_transition(1, "a");
+	states2[1].set_transition(2, "b");
+	states2[2].set_transition(2, "a");
+	states2[2].set_transition(2, "b");
 
 	states2[1].is_terminal = true;
 
-	FiniteAutomaton dfa1 = FiniteAutomaton(0, states1, {'a', 'b'});
-	FiniteAutomaton dfa2 = FiniteAutomaton(0, states2, {'a', 'b'});
+	FiniteAutomaton dfa1 = FiniteAutomaton(0, states1, {"a", "b"});
+	FiniteAutomaton dfa2 = FiniteAutomaton(0, states2, {"a", "b"});
 
 	cout << FiniteAutomaton::intersection(dfa1, dfa2).to_txt();
 }
@@ -153,17 +153,17 @@ void Example::fa_bisimilar_check() {
 			i, {i}, to_string(i), false, map<alphabet_symbol, set<int>>()};
 		states1.push_back(s);
 	}
-	states1[0].set_transition(1, 'a');
-	states1[0].set_transition(1, '\0');
-	states1[0].set_transition(2, 'b');
-	states1[1].set_transition(2, 'a');
-	states1[1].set_transition(1, 'b');
-	states1[2].set_transition(1, 'a');
-	states1[2].set_transition(1, '\0');
-	states1[2].set_transition(0, 'b');
+	states1[0].set_transition(1, "a");
+	states1[0].set_transition(1, "eps");
+	states1[0].set_transition(2, "b");
+	states1[1].set_transition(2, "a");
+	states1[1].set_transition(1, "b");
+	states1[2].set_transition(1, "a");
+	states1[2].set_transition(1, "eps");
+	states1[2].set_transition(0, "b");
 	states1[0].is_terminal = true;
 	states1[2].is_terminal = true;
-	FiniteAutomaton fa1(1, states1, {'a', 'b'});
+	FiniteAutomaton fa1(1, states1, {"a", "b"});
 
 	vector<State> states2;
 	for (int i = 0; i < 2; i++) {
@@ -171,13 +171,13 @@ void Example::fa_bisimilar_check() {
 			i, {i}, to_string(i), false, map<alphabet_symbol, set<int>>()};
 		states2.push_back(s);
 	}
-	states2[0].set_transition(1, 'a');
-	states2[0].set_transition(1, '\0');
-	states2[0].set_transition(0, 'b');
-	states2[1].set_transition(0, 'a');
-	states2[1].set_transition(1, 'b');
+	states2[0].set_transition(1, "a");
+	states2[0].set_transition(1, "eps");
+	states2[0].set_transition(0, "b");
+	states2[1].set_transition(0, "a");
+	states2[1].set_transition(1, "b");
 	states2[0].is_terminal = true;
-	FiniteAutomaton fa2(1, states2, {'a', 'b'});
+	FiniteAutomaton fa2(1, states2, {"a", "b"});
 
 	cout << FiniteAutomaton::bisimilar(fa1, fa2);
 	//правильный ответ true
@@ -190,16 +190,16 @@ void Example::fa_equal_check() {
 			i, {i}, to_string(i), false, map<alphabet_symbol, set<int>>()};
 		states1.push_back(s);
 	}
-	states1[0].set_transition(1, 'b');
-	states1[0].set_transition(2, 'b');
-	states1[0].set_transition(5, 'c');
-	states1[1].set_transition(3, 'a');
-	states1[1].set_transition(4, 'c');
-	states1[2].set_transition(4, 'a');
-	states1[5].set_transition(4, 'a');
+	states1[0].set_transition(1, "b");
+	states1[0].set_transition(2, "b");
+	states1[0].set_transition(5, "c");
+	states1[1].set_transition(3, "a");
+	states1[1].set_transition(4, "c");
+	states1[2].set_transition(4, "a");
+	states1[5].set_transition(4, "a");
 	states1[3].is_terminal = true;
 	states1[4].is_terminal = true;
-	FiniteAutomaton fa1(0, states1, {'a', 'b', 'c'});
+	FiniteAutomaton fa1(0, states1, {"a", "b", "c"});
 
 	vector<State> states2;
 	for (int i = 0; i < 6; i++) {
@@ -207,16 +207,16 @@ void Example::fa_equal_check() {
 			i, {i}, to_string(i), false, map<alphabet_symbol, set<int>>()};
 		states2.push_back(s);
 	}
-	states2[0].set_transition(1, 'b');
-	states2[0].set_transition(2, 'b');
-	states2[0].set_transition(5, 'c');
-	states2[1].set_transition(3, 'a');
-	states2[1].set_transition(3, 'c');
-	states2[2].set_transition(4, 'a');
-	states2[5].set_transition(4, 'a');
+	states2[0].set_transition(1, "b");
+	states2[0].set_transition(2, "b");
+	states2[0].set_transition(5, "c");
+	states2[1].set_transition(3, "a");
+	states2[1].set_transition(3, "c");
+	states2[2].set_transition(4, "a");
+	states2[5].set_transition(4, "a");
 	states2[3].is_terminal = true;
 	states2[4].is_terminal = true;
-	FiniteAutomaton fa2(0, states2, {'a', 'b', 'c'});
+	FiniteAutomaton fa2(0, states2, {"a", "b", "c"});
 
 	vector<State> states3;
 	for (int i = 0; i < 6; i++) {
@@ -224,16 +224,16 @@ void Example::fa_equal_check() {
 			i, {i}, to_string(i), false, map<alphabet_symbol, set<int>>()};
 		states3.push_back(s);
 	}
-	states3[5].set_transition(4, 'b');
-	states3[5].set_transition(3, 'b');
-	states3[5].set_transition(0, 'c');
-	states3[4].set_transition(2, 'a');
-	states3[4].set_transition(1, 'c');
-	states3[3].set_transition(1, 'a');
-	states3[0].set_transition(1, 'a');
+	states3[5].set_transition(4, "b");
+	states3[5].set_transition(3, "b");
+	states3[5].set_transition(0, "c");
+	states3[4].set_transition(2, "a");
+	states3[4].set_transition(1, "c");
+	states3[3].set_transition(1, "a");
+	states3[0].set_transition(1, "a");
 	states3[2].is_terminal = true;
 	states3[1].is_terminal = true;
-	FiniteAutomaton fa3(5, states3, {'a', 'b', 'c'});
+	FiniteAutomaton fa3(5, states3, {"a", "b", "c"});
 
 	cout << FiniteAutomaton::equal(fa1, fa1) << endl
 		 << FiniteAutomaton::equal(fa1, fa2) << endl
@@ -248,17 +248,17 @@ void Example::fa_merge_bisimilar() {
 			i, {i}, to_string(i), false, map<alphabet_symbol, set<int>>()};
 		states1.push_back(s);
 	}
-	states1[0].set_transition(1, 'a');
-	states1[0].set_transition(1, '\0');
-	states1[0].set_transition(2, 'b');
-	states1[1].set_transition(2, 'a');
-	states1[1].set_transition(1, 'b');
-	states1[2].set_transition(1, 'a');
-	states1[2].set_transition(1, '\0');
-	states1[2].set_transition(0, 'b');
+	states1[0].set_transition(1, "a");
+	states1[0].set_transition(1, "eps");
+	states1[0].set_transition(2, "b");
+	states1[1].set_transition(2, "a");
+	states1[1].set_transition(1, "b");
+	states1[2].set_transition(1, "a");
+	states1[2].set_transition(1, "eps");
+	states1[2].set_transition(0, "b");
 	states1[0].is_terminal = true;
 	states1[2].is_terminal = true;
-	FiniteAutomaton fa1(1, states1, {'a', 'b'});
+	FiniteAutomaton fa1(1, states1, {"a", "b"});
 
 	cout << fa1.to_txt();
 
@@ -274,14 +274,14 @@ void Example::fa_equivalent_check() {
 			i, {i}, to_string(i), false, map<alphabet_symbol, set<int>>()};
 		states1.push_back(s);
 	}
-	states1[0].set_transition(0, 'c');
-	states1[0].set_transition(1, 'd');
-	states1[1].set_transition(2, 'c');
-	states1[1].set_transition(0, 'd');
-	states1[2].set_transition(1, 'c');
-	states1[2].set_transition(2, 'd');
+	states1[0].set_transition(0, "c");
+	states1[0].set_transition(1, "d");
+	states1[1].set_transition(2, "c");
+	states1[1].set_transition(0, "d");
+	states1[2].set_transition(1, "c");
+	states1[2].set_transition(2, "d");
 	states1[0].is_terminal = true;
-	FiniteAutomaton fa1(0, states1, {'c', 'd'});
+	FiniteAutomaton fa1(0, states1, {"c", "d"});
 
 	vector<State> states2;
 	for (int i = 0; i < 4; i++) {
@@ -289,16 +289,16 @@ void Example::fa_equivalent_check() {
 			i, {i}, to_string(i), false, map<alphabet_symbol, set<int>>()};
 		states2.push_back(s);
 	}
-	states2[0].set_transition(0, 'c');
-	states2[0].set_transition(1, 'd');
-	states2[1].set_transition(2, 'c');
-	states2[1].set_transition(0, 'd');
-	states2[2].set_transition(3, 'c');
-	states2[2].set_transition(2, 'd');
-	states2[3].set_transition(2, 'c');
-	states2[3].set_transition(0, 'd');
+	states2[0].set_transition(0, "c");
+	states2[0].set_transition(1, "d");
+	states2[1].set_transition(2, "c");
+	states2[1].set_transition(0, "d");
+	states2[2].set_transition(3, "c");
+	states2[2].set_transition(2, "d");
+	states2[3].set_transition(2, "c");
+	states2[3].set_transition(0, "d");
 	states2[0].is_terminal = true;
-	FiniteAutomaton fa2(0, states2, {'c', 'd'});
+	FiniteAutomaton fa2(0, states2, {"c", "d"});
 
 	cout << FiniteAutomaton::equivalent(fa1, fa2);
 }
@@ -310,13 +310,13 @@ void Example::fa_subset_check() {
 			i, {i}, to_string(i), false, map<alphabet_symbol, set<int>>()};
 		states1.push_back(s);
 	}
-	states1[0].set_transition(1, 'a');
-	states1[0].set_transition(1, 'b');
-	states1[0].set_transition(2, 'a');
-	states1[1].set_transition(3, 'b');
-	states1[2].set_transition(3, 'c');
+	states1[0].set_transition(1, "a");
+	states1[0].set_transition(1, "b");
+	states1[0].set_transition(2, "a");
+	states1[1].set_transition(3, "b");
+	states1[2].set_transition(3, "c");
 	states1[3].is_terminal = true;
-	FiniteAutomaton fa1(0, states1, {'a', 'b', 'c'});
+	FiniteAutomaton fa1(0, states1, {"a", "b", "c"});
 
 	vector<State> states2;
 	for (int i = 0; i < 3; i++) {
@@ -324,10 +324,10 @@ void Example::fa_subset_check() {
 			i, {i}, to_string(i), false, map<alphabet_symbol, set<int>>()};
 		states2.push_back(s);
 	}
-	states2[0].set_transition(1, 'b');
-	states2[1].set_transition(2, 'b');
+	states2[0].set_transition(1, "b");
+	states2[1].set_transition(2, "b");
 	states2[2].is_terminal = true;
-	FiniteAutomaton fa2(0, states2, {'a', 'b', 'c'});
+	FiniteAutomaton fa2(0, states2, {"a", "b", "c"});
 
 	cout << fa1.subset(fa2) << endl;
 }
@@ -335,20 +335,20 @@ void Example::fa_subset_check() {
 void Example::to_image() {
 	vector<State> states1;
 	for (int i = 0; i < 3; i++) {
-		State s = {i, {i}, to_string(i), false, map<char, set<int>>()};
+		State s = {i, {i}, to_string(i), false, map<string, set<int>>()};
 		states1.push_back(s);
 	}
-	states1[0].set_transition(1, 'a');
-	states1[0].set_transition(1, '\0');
-	states1[0].set_transition(2, 'b');
-	states1[1].set_transition(2, 'a');
-	states1[1].set_transition(1, 'b');
-	states1[2].set_transition(1, 'a');
-	states1[2].set_transition(1, '\0');
-	states1[2].set_transition(0, 'b');
+	states1[0].set_transition(1, "a");
+	states1[0].set_transition(1, "eps");
+	states1[0].set_transition(2, "b");
+	states1[1].set_transition(2, "a");
+	states1[1].set_transition(1, "b");
+	states1[2].set_transition(1, "a");
+	states1[2].set_transition(1, "eps");
+	states1[2].set_transition(0, "b");
 	states1[0].is_terminal = true;
 	states1[2].is_terminal = true;
-	FiniteAutomaton fa1(1, states1, {'a', 'b'});
+	FiniteAutomaton fa1(1, states1, {"a", "b"});
 
 	string s1 = fa1.to_txt();
 
@@ -367,17 +367,17 @@ void Example::step() {
 			i, {i}, to_string(i), false, map<alphabet_symbol, set<int>>()};
 		states1.push_back(s);
 	}
-	states1[0].set_transition(1, 'a');
-	states1[0].set_transition(1, '\0');
-	states1[0].set_transition(2, 'b');
-	states1[1].set_transition(2, 'a');
-	states1[1].set_transition(1, 'b');
-	states1[2].set_transition(1, 'a');
-	states1[2].set_transition(1, '\0');
-	states1[2].set_transition(0, 'b');
+	states1[0].set_transition(1, "a");
+	states1[0].set_transition(1, "eps");
+	states1[0].set_transition(2, "b");
+	states1[1].set_transition(2, "a");
+	states1[1].set_transition(1, "b");
+	states1[2].set_transition(1, "a");
+	states1[2].set_transition(1, "eps");
+	states1[2].set_transition(0, "b");
 	states1[0].is_terminal = true;
 	states1[2].is_terminal = true;
-	FiniteAutomaton fa1(1, states1, {'a', 'b'});
+	FiniteAutomaton fa1(1, states1, {"a", "b"});
 
 	string f1 = fa1.to_txt();
 

--- a/src/objects/FiniteAutomaton.cpp
+++ b/src/objects/FiniteAutomaton.cpp
@@ -530,6 +530,34 @@ FiniteAutomaton FiniteAutomaton::remove_trap_state() const {
 	return FiniteAutomaton();
 }
 
+FiniteAutomaton FiniteAutomaton::annote() const {
+	set<alphabet_symbol> new_alphabet;
+	FiniteAutomaton new_fa = FiniteAutomaton(initial_state, states, shared_ptr<Language>());
+	vector<map<alphabet_symbol, set<int>>> new_transitions(new_fa.states.size());
+	for (int i = 0; i < new_fa.states.size(); i++) {
+		for (const auto& elem : new_fa.states[i].transitions) {
+			if (elem.second.size() > 1) {
+				int counter = 1;
+				for (int transition_to : elem.second) {
+					alphabet_symbol new_symb = to_string(elem.first) + to_string(counter);
+					new_transitions[i][new_symb].insert(transition_to);
+					new_alphabet.insert(new_symb);
+					counter++;
+				}
+			}
+			else {
+				new_transitions[i][elem.first] = new_fa.states[i].transitions[elem.first];
+				new_alphabet.insert(elem.first);
+			}
+		}
+	}
+	new_fa.language = shared_ptr<Language>(new Language(new_alphabet));
+	for (int i = 0; i < new_transitions.size(); i++) {
+		new_fa.states[i].transitions = new_transitions[i];
+	}
+	return new_fa;
+}
+
 FiniteAutomaton FiniteAutomaton::merge_equivalent_classes(
 	vector<int> classes) const {
 	map<int, vector<int>>

--- a/src/objects/FiniteAutomaton.cpp
+++ b/src/objects/FiniteAutomaton.cpp
@@ -532,21 +532,53 @@ FiniteAutomaton FiniteAutomaton::remove_trap_state() const {
 
 FiniteAutomaton FiniteAutomaton::annote() const {
 	set<alphabet_symbol> new_alphabet;
-	FiniteAutomaton new_fa = FiniteAutomaton(initial_state, states, shared_ptr<Language>());
-	vector<map<alphabet_symbol, set<int>>> new_transitions(new_fa.states.size());
+	FiniteAutomaton new_fa =
+		FiniteAutomaton(initial_state, states, shared_ptr<Language>());
+	vector<map<alphabet_symbol, set<int>>> new_transitions(
+		new_fa.states.size());
 	for (int i = 0; i < new_fa.states.size(); i++) {
 		for (const auto& elem : new_fa.states[i].transitions) {
 			if (elem.second.size() > 1) {
 				int counter = 1;
 				for (int transition_to : elem.second) {
-					alphabet_symbol new_symb = to_string(elem.first) + to_string(counter);
+					alphabet_symbol new_symb =
+						to_string(elem.first) + to_string(counter);
 					new_transitions[i][new_symb].insert(transition_to);
 					new_alphabet.insert(new_symb);
 					counter++;
 				}
+			} else {
+				new_transitions[i][elem.first] =
+					new_fa.states[i].transitions[elem.first];
+				new_alphabet.insert(elem.first);
 			}
-			else {
-				new_transitions[i][elem.first] = new_fa.states[i].transitions[elem.first];
+		}
+	}
+	new_fa.language = shared_ptr<Language>(new Language(new_alphabet));
+	for (int i = 0; i < new_transitions.size(); i++) {
+		new_fa.states[i].transitions = new_transitions[i];
+	}
+	return new_fa;
+}
+
+FiniteAutomaton FiniteAutomaton::deannote() const {
+	set<alphabet_symbol> new_alphabet;
+	FiniteAutomaton new_fa =
+		FiniteAutomaton(initial_state, states, shared_ptr<Language>());
+	vector<map<alphabet_symbol, set<int>>> new_transitions(
+		new_fa.states.size());
+	for (int i = 0; i < new_fa.states.size(); i++) {
+		for (const auto& elem : new_fa.states[i].transitions) {
+			if (elem.first.size() > 1 && elem.first != epsilon()) {
+				string str = to_string(elem.first);
+				str.pop_back();
+				new_alphabet.insert(str);
+				for (int transition_to : elem.second) {
+					new_transitions[i][str].insert(transition_to);
+				}
+			} else {
+				new_transitions[i][elem.first] =
+					new_fa.states[i].transitions[elem.first];
 				new_alphabet.insert(elem.first);
 			}
 		}

--- a/src/objects/Grammar.cpp
+++ b/src/objects/Grammar.cpp
@@ -135,7 +135,7 @@ alphabet_symbol to_alphabet_symbol(string s) {
 	if (s == "\0")
 		return epsilon();
 	else
-		return s[0];
+		return s;
 }
 
 vector<vector<vector<GrammarItem*>>> tansitions_to_grammar(

--- a/src/objects/Regex.cpp
+++ b/src/objects/Regex.cpp
@@ -216,7 +216,7 @@ Regex* Regex::scan_symb(const vector<Lexem>& lexems, int index_start,
 	p->value = lexems[index_start];
 	p->type = Regex::symb;
 
-	vector<alphabet_symbol> v = {lexems[index_start].symbol};
+	vector<alphabet_symbol> v = {char_to_alphabet_symbol(lexems[index_start].symbol)};
 	set<alphabet_symbol> s(v.begin(), v.end());
 
 	p->alphabet = s;
@@ -408,7 +408,7 @@ pair<vector<State>, int> Regex::get_tompson(int max_index) {
 		max_index = ar.second;
 
 		str = "q" + to_string(max_index + 1);
-		m['\0'] = {1, int(al.first.size()) + 1};
+		m[epsilon()] = {1, int(al.first.size()) + 1};
 		s.push_back(State(0, {}, str, false, m));
 
 		for (size_t i = 0; i < al.first.size(); i++) {
@@ -423,7 +423,7 @@ pair<vector<State>, int> Regex::get_tompson(int max_index) {
 			}
 
 			if (test.is_terminal) {
-				map_l['\0'] = {int(al.first.size() + ar.first.size()) + 1};
+				map_l[epsilon()] = {int(al.first.size() + ar.first.size()) + 1};
 			}
 			s.push_back(State(al.first[i].index + 1, {}, al.first[i].identifier,
 							  false, map_l));
@@ -441,7 +441,7 @@ pair<vector<State>, int> Regex::get_tompson(int max_index) {
 				map_r[elem] = trans;
 			}
 			if (test.is_terminal) {
-				map_r['\0'] = {offset + int(ar.first.size())};
+				map_r[epsilon()] = {offset + int(ar.first.size())};
 			}
 
 			s.push_back(State(ar.first[i].index + offset, {},
@@ -511,7 +511,7 @@ pair<vector<State>, int> Regex::get_tompson(int max_index) {
 		max_index = al.second;
 
 		str = "q" + to_string(max_index + 1);
-		m['\0'] = {1, int(al.first.size()) + 1};
+		m[epsilon()] = {1, int(al.first.size()) + 1};
 		s.push_back(State(0, {}, str, false, m));
 
 		for (size_t i = 0; i < al.first.size(); i++) {
@@ -527,7 +527,7 @@ pair<vector<State>, int> Regex::get_tompson(int max_index) {
 			}
 
 			if (test.is_terminal) {
-				map_l['\0'] = {1, int(al.first.size()) + 1};
+				map_l[epsilon()] = {1, int(al.first.size()) + 1};
 			}
 			s.push_back(State(al.first[i].index + 1, {}, al.first[i].identifier,
 							  false, map_l));
@@ -542,7 +542,7 @@ pair<vector<State>, int> Regex::get_tompson(int max_index) {
 	case Regex::eps:
 		str = "q" + to_string(max_index + 1);
 
-		m['\0'] = {1};
+		m[epsilon()] = {1};
 		s.push_back(State(0, {}, str, false, m));
 		str = "q" + to_string(max_index + 2);
 		s.push_back(State(1, {}, str, true, p));
@@ -551,7 +551,7 @@ pair<vector<State>, int> Regex::get_tompson(int max_index) {
 	default:
 
 		str = "q" + to_string(max_index + 1);
-		m[value.symbol] = {1};
+		m[char_to_alphabet_symbol(value.symbol)] = {1};
 		s.push_back(State(0, {}, str, false, m));
 		str = "q" + to_string(max_index + 2);
 		s.push_back(State(1, {}, str, true, p));
@@ -753,7 +753,7 @@ FiniteAutomaton Regex::to_glushkov() {
 	map<alphabet_symbol, set<int>> tr; // мап для переходов в каждом состоянии
 
 	for (size_t i = 0; i < first->size(); i++) {
-		tr[(*first)[i].symbol].insert((*first)[i].number + 1);
+		tr[char_to_alphabet_symbol((*first)[i].symbol)].insert((*first)[i].number + 1);
 	}
 
 	st.push_back(State(0, {}, "S", false, tr));
@@ -763,7 +763,7 @@ FiniteAutomaton Regex::to_glushkov() {
 		tr = {};
 
 		for (size_t j = 0; j < p[elem.number].size(); j++) {
-			tr[list[p[elem.number][j]]->value.symbol].insert(p[elem.number][j] +
+			tr[char_to_alphabet_symbol(list[p[elem.number][j]]->value.symbol)].insert(p[elem.number][j] +
 															 1);
 		}
 		string s = elem.symbol + to_string(i + 1);


### PR DESCRIPTION
Убран нуль-терминальный символ для обозначения eps-переходов.

Добавлены функции `annote` и `deannote` для навешивания и снятия разметки с букв, стоящих на недетерминированных переходах.

Также исправлено поведение функции `reverse`, при котором добавление состояния `RevS` происходит при наличии в автомате одного финального состояния.