### PR TITLE
annoted flag added + semdet annote fix

### DIFF
--- a/include/objects/Language.h
+++ b/include/objects/Language.h
@@ -24,5 +24,6 @@ class Language {
 	const optional<int>& get_pump_length();
 	void set_min_dfa(FiniteAutomaton);
 	const optional<FiniteAutomaton>& get_min_dfa();
+	bool annoted = false;
 	// и тд
 };

--- a/src/objects/FiniteAutomaton.cpp
+++ b/src/objects/FiniteAutomaton.cpp
@@ -1356,7 +1356,7 @@ bool FiniteAutomaton::semdet() const {
 		Regex reg;
 		// Получение языка из производной регулярки автомата по префиксу:
 		//		this -> reg (arden?)
-		reg = annote().nfa_to_regex();
+		reg = nfa_to_regex();
 		// cout << "State: " << i << "\n";
 		// cout << "Prefix: " << prefix.value() << "\n";
 		// cout << "Regex: " << reg.to_txt() << "\n";

--- a/src/objects/FiniteAutomaton.cpp
+++ b/src/objects/FiniteAutomaton.cpp
@@ -693,6 +693,7 @@ FiniteAutomaton FiniteAutomaton::annote() const {
 		}
 	}
 	new_fa.language = shared_ptr<Language>(new Language(new_alphabet));
+	new_fa.language->annoted = true;
 	for (int i = 0; i < new_transitions.size(); i++) {
 		new_fa.states[i].transitions = new_transitions[i];
 	}
@@ -727,6 +728,7 @@ FiniteAutomaton FiniteAutomaton::deannote() const {
 		}
 	}
 	new_fa.language = shared_ptr<Language>(new Language(new_alphabet));
+	new_fa.language->annoted = false;
 	for (int i = 0; i < new_transitions.size(); i++) {
 		new_fa.states[i].transitions = new_transitions[i];
 	}
@@ -1336,6 +1338,9 @@ std::optional<std::string> FiniteAutomaton::get_prefix(
 }
 
 bool FiniteAutomaton::semdet() const {
+	if (!language->annoted) {
+		return annote().semdet();
+	}
 	std::map<int, bool> was;
 	std::vector<int> final_states;
 	for (int i = 0; i < states.size(); i++) {
@@ -1351,7 +1356,7 @@ bool FiniteAutomaton::semdet() const {
 		Regex reg;
 		// Получение языка из производной регулярки автомата по префиксу:
 		//		this -> reg (arden?)
-		reg = nfa_to_regex();
+		reg = annote().nfa_to_regex();
 		// cout << "State: " << i << "\n";
 		// cout << "Prefix: " << prefix.value() << "\n";
 		// cout << "Regex: " << reg.to_txt() << "\n";


### PR DESCRIPTION
Добавлен флаг annote в язык, изменяется в функции annote, deannote.
Теперь semdet запускается только на annote КА, если annote не было, то semdet запускается от annote копии КА.