### PR TITLE
Тесты Брюггеманн-Вуда

### DIFF
--- a/apps/TestsApp/include/TestsApp/Example.h
+++ b/apps/TestsApp/include/TestsApp/Example.h
@@ -22,7 +22,6 @@ class Example {
 	static void remove_eps();
 	static void minimize();
 	static void intersection();
-	static void is_one_unambiguous();
 	static void regex_parsing();
 	static void regex_generating();
 	static void random_regex_parsing();
@@ -50,4 +49,5 @@ class Example {
 	static void test_ambiguity();
 	static void test_arden();
 	static void test_pump_length();
+	static void test_is_one_unambiguous();
 };

--- a/apps/TestsApp/include/TestsApp/Example.h
+++ b/apps/TestsApp/include/TestsApp/Example.h
@@ -1,10 +1,10 @@
 #include "AutomatonToImage/AutomatonToImage.h"
+#include "InputGenerator/RegexGenerator.h"
+#include "InputGenerator/TasksGenerator.h"
 #include "Objects/FiniteAutomaton.h"
 #include "Objects/Language.h"
 #include "Objects/Logger.h"
 #include "Objects/Regex.h"
-#include "InputGenerator/TasksGenerator.h"
-#include "InputGenerator/RegexGenerator.h"
 #include "Objects/TransformationMonoid.h"
 #include "Tester/Tester.h"
 #include <cassert>
@@ -22,6 +22,7 @@ class Example {
 	static void remove_eps();
 	static void minimize();
 	static void intersection();
+	static void is_one_unambiguous();
 	static void regex_parsing();
 	static void regex_generating();
 	static void random_regex_parsing();

--- a/apps/TestsApp/src/Example.cpp
+++ b/apps/TestsApp/src/Example.cpp
@@ -119,25 +119,6 @@ void Example::intersection() {
 	cout << FiniteAutomaton::intersection(dfa1, dfa2).to_txt();
 }
 
-void Example::is_one_unambiguous() {
-	Regex r1("(a|b)*a");
-	Regex r2("(a|b)*(ac|bd)");
-	Regex r3("(a|b)*a(a|b)");
-	Regex r4("(c(a|b)*c)*");
-	Regex r5("a(bbb*aaa*)*bb*|aaa*(bbb*aaa*)*|b(aaa*bbb*)*aa*|");
-
-	// ok
-	cout << r1.to_glushkov().is_one_unambiguous() << endl;
-	// doesn't fulfills the orbit property
-	cout << r2.to_glushkov().is_one_unambiguous() << endl;
-	// consists of a single orbit, but neither a nor b is consistent
-	cout << r3.to_glushkov().is_one_unambiguous() << endl;
-	// ok
-	cout << r4.to_glushkov().is_one_unambiguous() << endl;
-	// doesn't fulfills the orbit property
-	cout << r5.to_glushkov().is_one_unambiguous() << endl;
-};
-
 void Example::regex_parsing() {
 	string regl = "a(bbb*aaa*)*bb*|aaa*(bbb*aaa*)*|b(aaa*bbb*)*aa*|";
 	string regr = "bbb*(aaa*bbb*)*"; //"((a|)*c)";
@@ -554,6 +535,7 @@ void Example::test_all() {
 	test_ambiguity();
 	// test_arden();
 	test_pump_length();
+	test_is_one_unambiguous();
 	cout << "all tests passed" << endl;
 }
 
@@ -774,3 +756,22 @@ void Example::test_arden() {
 void Example::test_pump_length() {
 	assert(Regex("abaa").pump_length() == 5);
 }
+
+void Example::test_is_one_unambiguous() {
+	Regex r1("(a|b)*a");
+	Regex r2("(a|b)*(ac|bd)");
+	Regex r3("(a|b)*a(a|b)");
+	Regex r4("(c(a|b)*c)*");
+	Regex r5("a(bbb*aaa*)*bb*|aaa*(bbb*aaa*)*|b(aaa*bbb*)*aa*|");
+
+	// ok
+	assert(r1.to_glushkov().is_one_unambiguous());
+	// doesn't fulfills the orbit property
+	assert(r2.to_glushkov().is_one_unambiguous() == 0);
+	// consists of a single orbit, but neither a nor b is consistent
+	assert(r3.to_glushkov().is_one_unambiguous() == 0);
+	// ok
+	assert(r4.to_glushkov().is_one_unambiguous());
+	// doesn't fulfills the orbit property
+	assert(r5.to_glushkov().is_one_unambiguous() == 0);
+};

--- a/apps/TestsApp/src/Example.cpp
+++ b/apps/TestsApp/src/Example.cpp
@@ -119,6 +119,25 @@ void Example::intersection() {
 	cout << FiniteAutomaton::intersection(dfa1, dfa2).to_txt();
 }
 
+void Example::is_one_unambiguous() {
+	Regex r1("(a|b)*a");
+	Regex r2("(a|b)*(ac|bd)");
+	Regex r3("(a|b)*a(a|b)");
+	Regex r4("(c(a|b)*c)*");
+	Regex r5("a(bbb*aaa*)*bb*|aaa*(bbb*aaa*)*|b(aaa*bbb*)*aa*|");
+
+	// ok
+	cout << r1.to_glushkov().is_one_unambiguous() << endl;
+	// doesn't fulfills the orbit property
+	cout << r2.to_glushkov().is_one_unambiguous() << endl;
+	// consists of a single orbit, but neither a nor b is consistent
+	cout << r3.to_glushkov().is_one_unambiguous() << endl;
+	// ok
+	cout << r4.to_glushkov().is_one_unambiguous() << endl;
+	// doesn't fulfills the orbit property
+	cout << r5.to_glushkov().is_one_unambiguous() << endl;
+};
+
 void Example::regex_parsing() {
 	string regl = "a(bbb*aaa*)*bb*|aaa*(bbb*aaa*)*|b(aaa*bbb*)*aa*|";
 	string regr = "bbb*(aaa*bbb*)*"; //"((a|)*c)";

--- a/apps/TestsApp/src/Example.cpp
+++ b/apps/TestsApp/src/Example.cpp
@@ -767,11 +767,11 @@ void Example::test_is_one_unambiguous() {
 	// ok
 	assert(r1.to_glushkov().is_one_unambiguous());
 	// doesn't fulfills the orbit property
-	assert(r2.to_glushkov().is_one_unambiguous() == 0);
+	assert(!r2.to_glushkov().is_one_unambiguous());
 	// consists of a single orbit, but neither a nor b is consistent
-	assert(r3.to_glushkov().is_one_unambiguous() == 0);
+	assert(!r3.to_glushkov().is_one_unambiguous());
 	// ok
 	assert(r4.to_glushkov().is_one_unambiguous());
 	// doesn't fulfills the orbit property
-	assert(r5.to_glushkov().is_one_unambiguous() == 0);
+	assert(!r5.to_glushkov().is_one_unambiguous());
 };

--- a/libs/Objects/src/FiniteAutomaton.cpp
+++ b/libs/Objects/src/FiniteAutomaton.cpp
@@ -848,16 +848,18 @@ bool FiniteAutomaton::is_one_unambiguous() {
 				}
 			}
 		}
-		for (auto final_state_transitions : final_states_transitions) {
-			for (int elem : reachable_by_symb) {
+		for (int elem : reachable_by_symb) {
+			is_symb_min_fa_consistent = true;
+			for (auto final_state_transitions : final_states_transitions) {
 				if (find(final_state_transitions[symb].begin(),
 						 final_state_transitions[symb].end(),
 						 elem) == final_state_transitions[symb].end()) {
 					is_symb_min_fa_consistent = false;
+					break;
 				}
 			}
+			if (is_symb_min_fa_consistent) min_fa_consistent.insert(symb);
 		}
-		if (is_symb_min_fa_consistent) min_fa_consistent.insert(symb);
 	}
 
 	// calculate an orbit of each state
@@ -866,6 +868,7 @@ bool FiniteAutomaton::is_one_unambiguous() {
 	set<set<int>> min_fa_orbits;
 	for (int i = 0; i < min_fa.states.size(); i++) {
 		set<int> orbit_of_state;
+		orbit_of_state.insert(i);
 		set<int> reachable_states = min_fa.closure({i}, false);
 		for (int reachable_state : reachable_states) {
 			set<int> reachable_states_for_reachable =
@@ -884,8 +887,7 @@ bool FiniteAutomaton::is_one_unambiguous() {
 		}
 		// check if orbit of this state is trivial
 		// if so, insert into states_with_trivial_orbit
-		if (orbit_of_state.size() == 1 && *orbit_of_state.begin() == i &&
-			!is_state_has_transitions_to_itself) {
+		if (orbit_of_state.size() == 1 && !is_state_has_transitions_to_itself) {
 			states_with_trivial_orbit.insert(i);
 		}
 		min_fa_orbits.insert(orbit_of_state);
@@ -1032,7 +1034,7 @@ bool FiniteAutomaton::is_one_unambiguous() {
 	}
 	if (!is_min_fa_cut_has_an_orbit_property) return false;
 
-	// check if all orbit languages of min_fa_cut are 1-ambiguous
+	// check if all orbit languages of min_fa_cut are 1-unambiguous
 	int i = 0;
 	for (auto min_fa_cut_orbit : min_fa_cut_orbits) {
 		int orbit_automaton_initial_state = 0;
@@ -1059,9 +1061,13 @@ bool FiniteAutomaton::is_one_unambiguous() {
 				for (const auto& symb_transitions :
 					 orbit_automaton.states[j].transitions) {
 					set<int> orbit_automaton_symb_transitions;
+					int k = 0;
 					for (int transition : symb_transitions.second) {
-						if (transition < orbit_automaton.states.size()) {
-							orbit_automaton_symb_transitions.insert(transition);
+						if (find(min_fa_cut_orbit.begin(),
+								 min_fa_cut_orbit.end(),
+								 transition) != min_fa_cut_orbit.end()) {
+							orbit_automaton_symb_transitions.insert(k);
+							k++;
 						}
 					}
 					if (orbit_automaton_symb_transitions.size()) {


### PR DESCRIPTION
- Добавлены тесты метода `is_one_unambiguous` проверки регулярного языка на 1-однозначность методом орбит Брюггеманн-Вуда.

- В этом же методе исправлены недочёты построения орбитального автомата.