### PR TITLE
Kabanchique Interpreter update 🐗 

### DIFF
--- a/apps/InputGeneratorApp/src/main.cpp
+++ b/apps/InputGeneratorApp/src/main.cpp
@@ -33,10 +33,7 @@ int main() {
 	TG.write_to_file("test.txt");
 
 	// Загружаем в интерпретатор файл с коммандами
-	interpreter.load_file("test.txt");
-
-	// Выполняем коммнады
-	interpreter.run_all();
+	interpreter.run_file("test.txt");
 
 	// Гененрируем выходной документ, завершаем работу логгера
 	Logger::finish();

--- a/apps/InterpreterApp/src/main.cpp
+++ b/apps/InterpreterApp/src/main.cpp
@@ -20,10 +20,7 @@ int main(int argc, char* argv[]) {
 	// Загружаем в интерпретатор файл с коммандами
 	string load_file = "test.txt";
 	if (argc > 1) load_file = argv[1];
-	interpreter.load_file(load_file);
-
-	// Выполняем коммнады
-	interpreter.run_all();
+	interpreter.run_file(load_file);
 
 	// Гененрируем выходной документ, завершаем работу логгера
 	Logger::finish();

--- a/apps/TestsApp/CMakeLists.txt
+++ b/apps/TestsApp/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories( ${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
  	InputGenerator
+ 	Interpreter
  	Tester
  	Objects
 )

--- a/apps/TestsApp/include/TestsApp/Example.h
+++ b/apps/TestsApp/include/TestsApp/Example.h
@@ -7,6 +7,7 @@
 #include "Objects/Regex.h"
 #include "Objects/TransformationMonoid.h"
 #include "Tester/Tester.h"
+#include "Interpreter/Interpreter.h"
 #include <cassert>
 #include <iostream>
 /*
@@ -50,4 +51,5 @@ class Example {
 	static void test_arden();
 	static void test_pump_length();
 	static void test_is_one_unambiguous();
+	static void test_interpreter();
 };

--- a/apps/TestsApp/src/Example.cpp
+++ b/apps/TestsApp/src/Example.cpp
@@ -536,7 +536,8 @@ void Example::test_all() {
 	// test_arden();
 	test_pump_length();
 	test_is_one_unambiguous();
-	cout << "all tests passed" << endl;
+	test_interpreter();
+	cout << "all tests passed\n\n";
 }
 
 void Example::test_fa_equal() {
@@ -775,3 +776,14 @@ void Example::test_is_one_unambiguous() {
 	// doesn't fulfills the orbit property
 	assert(!r5.to_glushkov().is_one_unambiguous());
 };
+
+void Example::test_interpreter() {
+	Interpreter interpreter;
+	interpreter.set_log_mode(Interpreter::LogMode::nothing);
+	assert(!interpreter.run_line("A = Annote (Glushkova {a})"));
+	assert(interpreter.run_line("N1 = ((Glushkov ({ab|a})))"));
+	assert(interpreter.run_line("N2 =  (Annote N1)"));
+	assert(!interpreter.run_line("N2 =  (Glushkov N1)"));
+	assert(!interpreter.run_line("Equiv N1 N3"));
+	assert(interpreter.run_line("Equiv ((N1)) ((Reverse.Reverse (N2)))"));
+}

--- a/apps/TestsApp/src/Example.cpp
+++ b/apps/TestsApp/src/Example.cpp
@@ -787,4 +787,11 @@ void Example::test_interpreter() {
 	assert(!interpreter.run_line("Equiv N1 N3"));
 	assert(interpreter.run_line("Equiv ((N1)) ((Reverse.Reverse (N2)))"));
 	assert(interpreter.run_line("Test (Glushkov {a*}) {a*} 1"));
-}
+
+	assert(interpreter.run_line("A = Annote.Glushkov.DeAnnote {a}"));
+	assert(interpreter.run_line("B = Annote (Glushkov.DeAnnote {a})"));
+	assert(interpreter.run_line("B = Annote (Glushkov(DeAnnote {a}))"));
+	assert(interpreter.run_line("A = Annote.Glushkov.DeAnnote {a} !!"));
+	assert(interpreter.run_line("B = Annote (Glushkov.DeAnnote {a}) !!"));
+	assert(interpreter.run_line("B = Annote (Glushkov(DeAnnote {a})) !!"));
+} 

--- a/apps/TestsApp/src/Example.cpp
+++ b/apps/TestsApp/src/Example.cpp
@@ -779,7 +779,7 @@ void Example::test_is_one_unambiguous() {
 
 void Example::test_interpreter() {
 	Interpreter interpreter;
-	//interpreter.set_log_mode(Interpreter::LogMode::nothing);
+	interpreter.set_log_mode(Interpreter::LogMode::nothing);
 	assert(!interpreter.run_line("A = Annote (Glushkova {a})"));
 	assert(interpreter.run_line("N1 = ((Glushkov ({ab|a})))"));
 	assert(interpreter.run_line("N2 =  (Annote N1)"));

--- a/apps/TestsApp/src/Example.cpp
+++ b/apps/TestsApp/src/Example.cpp
@@ -786,4 +786,5 @@ void Example::test_interpreter() {
 	assert(!interpreter.run_line("N2 =  (Glushkov N1)"));
 	assert(!interpreter.run_line("Equiv N1 N3"));
 	assert(interpreter.run_line("Equiv ((N1)) ((Reverse.Reverse (N2)))"));
+	assert(interpreter.run_line("Test (Glushkov {a*}) {a*} 1"));
 }

--- a/apps/TestsApp/src/Example.cpp
+++ b/apps/TestsApp/src/Example.cpp
@@ -779,7 +779,7 @@ void Example::test_is_one_unambiguous() {
 
 void Example::test_interpreter() {
 	Interpreter interpreter;
-	interpreter.set_log_mode(Interpreter::LogMode::nothing);
+	//interpreter.set_log_mode(Interpreter::LogMode::nothing);
 	assert(!interpreter.run_line("A = Annote (Glushkova {a})"));
 	assert(interpreter.run_line("N1 = ((Glushkov ({ab|a})))"));
 	assert(interpreter.run_line("N2 =  (Annote N1)"));

--- a/libs/InputGenerator/src/RegexGenerator.cpp
+++ b/libs/InputGenerator/src/RegexGenerator.cpp
@@ -52,7 +52,7 @@ string RegexGenerator::generate_regex() {
 	cur_regex_length = regex_length;
 	cur_star_num = star_num;
 	generate_regex_(); // не порождает пустое слово, но так и задумано
-	return res_str;
+	return "{" + res_str + "}";
 }
 
 void RegexGenerator::generate_regex_() { // <regex> ::= <n-alt-regex> <alt>

--- a/libs/Interpreter/include/Interpreter/Interpreter.h
+++ b/libs/Interpreter/include/Interpreter/Interpreter.h
@@ -16,10 +16,10 @@ class Interpreter {
   public:
 	enum class LogMode { all, errors, nothing };
 	Interpreter();
-	// Загрузить программу из файла
-	void load_file(const string& filename);
-	// Выполнить все опреации
-	void run_all();
+	// Интерпретация строчки, возвращает true в случае успеха
+	bool run_line(const string& line);
+	// Интерпретация файла построчно
+	bool run_file(const string& path);
 	// Установит режим логгирования в консоль
 	void set_log_mode(LogMode mode);
 

--- a/libs/Interpreter/include/Interpreter/Interpreter.h
+++ b/libs/Interpreter/include/Interpreter/Interpreter.h
@@ -51,7 +51,7 @@ class Interpreter {
 	struct FunctionSequence {
 		// Композиция функций
 		vector<Function> functions;
-		// Параметры композиции функций (1 или более). Могут содержать ID
+		// Параметры композиции функций (1 или более)
 		vector<Expression> parameters;
 	};
 

--- a/libs/Interpreter/include/Interpreter/Interpreter.h
+++ b/libs/Interpreter/include/Interpreter/Interpreter.h
@@ -33,11 +33,11 @@ class Interpreter {
 	void throw_error(const string& str);
 
 	// Применение цепочки функций к набору аргументов
-	static GeneralObject apply_function_sequence(
+	GeneralObject apply_function_sequence(
 		const vector<Function>& functions, vector<GeneralObject> arguments);
 
 	// Применение функции к набору аргументов
-	static GeneralObject apply_function(const Function& function,
+	GeneralObject apply_function(const Function& function,
 										const vector<GeneralObject>& arguments);
 
 	// Тут хранятся объекты по их id

--- a/libs/Interpreter/include/Interpreter/Interpreter.h
+++ b/libs/Interpreter/include/Interpreter/Interpreter.h
@@ -119,9 +119,11 @@ class Interpreter {
 
 	//== Исполнение комманд ===================================================
 
-	// Преобразование списка параметров в список аргументов
-	vector<GeneralObject> parameters_to_arguments(
-		const vector<variant<string, GeneralObject>>& parameters);
+	// Вычисление выражения
+	optional<GeneralObject> eval_expression(const Expression& expr);
+
+	// Вычисление последовательности функций
+	optional<GeneralObject> eval_function_sequence(const FunctionSequence& seq);
 
 	// Исполнение операций
 	bool run_declaration(const Declaration&);
@@ -141,6 +143,8 @@ class Interpreter {
 
 	// Соответствие между названиями функций и сигнатурами
 	map<string, vector<Function>> names_to_functions;
+
+	//== Лексер ===============================================================
 
 	struct Lexem {
 		enum Type { // TODO добавить тип строки (для filename)

--- a/libs/Interpreter/include/Interpreter/Interpreter.h
+++ b/libs/Interpreter/include/Interpreter/Interpreter.h
@@ -29,16 +29,32 @@ class Interpreter {
 
 	// Вывод
 	LogMode log_mode = LogMode::all;
-	void log(const string& str);
-	void throw_error(const string& str);
+	int log_nesting = 0;
+
+	class InterpreterLogger {
+	  public:
+		InterpreterLogger(Interpreter& parent) : parent(parent) {
+			parent.log_nesting++;
+		}
+		~InterpreterLogger() {
+			parent.log_nesting--;
+		}
+		void log(const string& str);
+		void throw_error(const string& str);
+
+	  private:
+		Interpreter& parent;
+	};
+
+	InterpreterLogger init_log();
 
 	// Применение цепочки функций к набору аргументов
-	GeneralObject apply_function_sequence(
-		const vector<Function>& functions, vector<GeneralObject> arguments);
+	GeneralObject apply_function_sequence(const vector<Function>& functions,
+										  vector<GeneralObject> arguments);
 
 	// Применение функции к набору аргументов
 	GeneralObject apply_function(const Function& function,
-										const vector<GeneralObject>& arguments);
+								 const vector<GeneralObject>& arguments);
 
 	// Тут хранятся объекты по их id
 	map<string, GeneralObject> objects;

--- a/libs/Interpreter/include/Interpreter/Interpreter.h
+++ b/libs/Interpreter/include/Interpreter/Interpreter.h
@@ -124,10 +124,10 @@ class Interpreter {
 		const vector<variant<string, GeneralObject>>& parameters);
 
 	// Исполнение операций
-	void run_declaration(const Declaration&);
-	void run_predicate(const Predicate&);
-	void run_test(const Test&);
-	void run_operation(const GeneralOperation&);
+	bool run_declaration(const Declaration&);
+	bool run_predicate(const Predicate&);
+	bool run_test(const Test&);
+	bool run_operation(const GeneralOperation&);
 
 	// Список опреаций для последовательного выполнения
 	vector<GeneralOperation> operations;

--- a/libs/Interpreter/include/Interpreter/Interpreter.h
+++ b/libs/Interpreter/include/Interpreter/Interpreter.h
@@ -99,11 +99,15 @@ class Interpreter {
 
 	struct Lexem;
 
-	optional<Id> scan_Id(const vector<Lexem>&, int& pos);
-	optional<Regex> scan_Regex(const vector<Lexem>&, int& pos);
+	// Находит парную закрывающую скобку
+	int find_closing_par(const vector<Lexem>&, size_t pos);
+
+	optional<Id> scan_Id(const vector<Lexem>&, int& pos, size_t end);
+	optional<Regex> scan_Regex(const vector<Lexem>&, int& pos, size_t end);
 	optional<FunctionSequence> scan_FunctionSequence(const vector<Lexem>&,
-													 int& pos);
-	optional<Expression> scan_Expression(const vector<Lexem>&, int& pos);
+													 int& pos, size_t end);
+	optional<Expression> scan_Expression(const vector<Lexem>&, int& pos,
+										 size_t end);
 
 	// Типизация идентификаторов. Нужна для корректного составления опреаций
 	map<string, ObjectType> id_types;

--- a/libs/Interpreter/src/Interpreter.Lexer.cpp
+++ b/libs/Interpreter/src/Interpreter.Lexer.cpp
@@ -38,8 +38,18 @@ string Interpreter::Lexer::scan_until_space() {
 	string acc = "";
 	skip_spaces();
 	while (!eof() && current_symbol() != ' ' && current_symbol() != '\n' &&
-		   current_symbol() != '\t') {
+		   current_symbol() != '\t' && current_symbol() != '.' &&
+		   current_symbol() != '(' && current_symbol() != ')') {
 
+		acc += current_symbol();
+		next_symbol();
+	}
+	return acc;
+}
+
+string Interpreter::Lexer::scan_until(char symbol) {
+	string acc = "";
+	while (!eof() && current_symbol() != symbol) {
 		acc += current_symbol();
 		next_symbol();
 	}
@@ -60,22 +70,16 @@ Interpreter::Lexem Interpreter::Lexer::scan_doubleExclamation() {
 	return Lexem(Lexem::error);
 }
 
-Interpreter::Lexem Interpreter::Lexer::scan_function() {
-	for (const auto& function : functions) {
-		if (scan_word(function)) {
-			return Lexem(Lexem::function, function);
-		}
+Interpreter::Lexem Interpreter::Lexer::scan_parL() {
+	if (scan_word("(")) {
+		return Lexem(Lexem::parL);
 	}
 	return Lexem(Lexem::error);
 }
 
-Interpreter::Lexem Interpreter::Lexer::scan_id() {
-	// TODO: сделать проверки на корректность имени, чтобы не
-	// начиналось с цифры, не было коллизий с именами функций
-	string id_name = scan_until_space();
-	if (id_name.size()) {
-		ids.insert(id_name);
-		return Lexem(Lexem::id, id_name);
+Interpreter::Lexem Interpreter::Lexer::scan_parR() {
+	if (scan_word(")")) {
+		return Lexem(Lexem::parR);
 	}
 	return Lexem(Lexem::error);
 }
@@ -84,24 +88,6 @@ Interpreter::Lexem Interpreter::Lexer::scan_dot() {
 	if (scan_word(".")) {
 		return Lexem(Lexem::dot);
 	}
-	return Lexem(Lexem::error);
-}
-
-Interpreter::Lexem Interpreter::Lexer::scan_regex() {
-	input.save();
-	string word = scan_until_space();
-	Regex regex;
-	if (regex.from_string(word)) {
-		Lexem lex(Lexem::regex);
-		// TODO: это отвратительный костыль, надо использовать operator= как
-		// будет готов
-		lex.reg.from_string(word);
-		// TODO: А это отвратительный костыль, который нужен, чтобы потом
-		// превратить regex в id
-		lex.value = word;
-		return lex;
-	}
-	input.restore();
 	return Lexem(Lexem::error);
 }
 
@@ -120,24 +106,34 @@ Interpreter::Lexem Interpreter::Lexer::scan_number() {
 	return Lexem(stoi(acc));
 }
 
-Interpreter::Lexem Interpreter::Lexer::scan_predicate() {
-	for (const auto& predicate : predicates) {
-		if (scan_word(predicate)) {
-			return Lexem(Lexem::predicate, predicate);
-		}
+Interpreter::Lexem Interpreter::Lexer::scan_name() {
+	string name = scan_until_space();
+	if (name.size()) {
+		return Lexem(Lexem::name, name);
 	}
 	return Lexem(Lexem::error);
 }
 
-Interpreter::Lexem Interpreter::Lexer::scan_test() {
-	if (scan_word("Test")) {
-		return Lexem(Lexem::test);
+Interpreter::Lexem Interpreter::Lexer::scan_regex() {
+	if (scan_word("{")) {
+		string val = scan_until('}');
+		scan_word("}");
+		return Lexem(Lexem::regex, val);
 	}
 	return Lexem(Lexem::error);
 }
 
 Interpreter::Lexem Interpreter::Lexer::scan_lexem() {
+	if (Lexem lex = scan_parL(); lex.type) {
+		return lex;
+	}
+	if (Lexem lex = scan_parR(); lex.type) {
+		return lex;
+	}
 	if (Lexem lex = scan_dot(); lex.type) {
+		return lex;
+	}
+	if (Lexem lex = scan_regex(); lex.type) {
 		return lex;
 	}
 	if (Lexem lex = scan_number(); lex.type) {
@@ -149,19 +145,7 @@ Interpreter::Lexem Interpreter::Lexer::scan_lexem() {
 	if (Lexem lex = scan_doubleExclamation(); lex.type) {
 		return lex;
 	}
-	if (Lexem lex = scan_function(); lex.type) {
-		return lex;
-	}
-	if (Lexem lex = scan_predicate(); lex.type) {
-		return lex;
-	}
-	if (Lexem lex = scan_test(); lex.type) {
-		return lex;
-	}
-	if (Lexem lex = scan_regex(); lex.type) {
-		return lex;
-	}
-	if (Lexem lex = scan_id(); lex.type) {
+	if (Lexem lex = scan_name(); lex.type) {
 		return lex;
 	}
 	parent.log("Lexer: failed to scan \"" +

--- a/libs/Interpreter/src/Interpreter.Lexer.cpp
+++ b/libs/Interpreter/src/Interpreter.Lexer.cpp
@@ -148,7 +148,8 @@ Interpreter::Lexem Interpreter::Lexer::scan_lexem() {
 	if (Lexem lex = scan_name(); lex.type) {
 		return lex;
 	}
-	parent.log("Lexer: failed to scan \"" +
+	auto logger = parent.init_log();
+	logger.log("Lexer: failed to scan \"" +
 			   input.str.substr(input.pos, input.str.size()) + "\"");
 	return Lexem(Lexem::error);
 }
@@ -158,10 +159,11 @@ Interpreter::Lexem::Lexem(Type type, string value) : type(type), value(value) {}
 Interpreter::Lexem::Lexem(int num) : num(num), type(number) {}
 
 vector<vector<Interpreter::Lexem>> Interpreter::Lexer::load_file(string path) {
-	parent.log("Lexer: loading file " + path);
+	auto logger = parent.init_log();
+	logger.log("Lexer: loading file " + path);
 	ifstream input_file(path);
 	if (!input_file) {
-		parent.throw_error("Error: failed to open " + to_string(path));
+		logger.throw_error("Error: failed to open " + to_string(path));
 	}
 	// Сюда будем записывать строки из лексем
 	vector<vector<Lexem>> lexem_lines = {};
@@ -169,10 +171,10 @@ vector<vector<Interpreter::Lexem>> Interpreter::Lexer::load_file(string path) {
 	while (getline(input_file, str)) {
 		if (auto lexems = parse_string(str); lexems.size()) {
 			lexem_lines.push_back(lexems);
-			parent.log("scanned line: " + str);
+			logger.log("scanned line: " + str);
 		}
 	}
-	parent.log("Lexer: file loaded");
+	logger.log("Lexer: file loaded");
 	return lexem_lines;
 }
 

--- a/libs/Interpreter/src/Interpreter.cpp
+++ b/libs/Interpreter/src/Interpreter.cpp
@@ -69,13 +69,15 @@ bool Interpreter::run_line(const string& line) {
 	Lexer lexer(*this);
 	log("running \"" + line + "\"");
 	auto lexems = lexer.parse_string(line);
+	bool success = false;
 	if (const auto op = scan_operation(lexems); op.has_value()) {
-		run_operation(*op);
+		success = run_operation(*op);
 	} else {
 		throw_error("failed to scan operation");
-		return false;
+		success = false;
 	}
-	return true;
+	log("");
+	return success;
 }
 
 bool Interpreter::run_file(const string& path) {
@@ -505,7 +507,7 @@ vector<GeneralObject> Interpreter::parameters_to_arguments(
 	return arguments;
 }
 
-void Interpreter::run_declaration(const Declaration& decl) {
+bool Interpreter::run_declaration(const Declaration& decl) {
 	log("Running declaration...");
 	/*if (decl.show_result) {
 		Logger::activate();
@@ -517,18 +519,20 @@ void Interpreter::run_declaration(const Declaration& decl) {
 		decl.function_sequence, parameters_to_arguments(decl.));
 	log("    assigned to " + to_string(decl.id));*/
 	Logger::deactivate();
+	return true;
 }
 
-void Interpreter::run_predicate(const Predicate& pred) {
+bool Interpreter::run_predicate(const Predicate& pred) {
 	log("Running predicate...");
 	/*Logger::activate();
 	auto res = apply_function(pred.predicate,
 							  parameters_to_arguments(pred.parameters));
 	log("    result: " + to_string(get<ObjectBoolean>(res).value));*/
 	Logger::deactivate();
+	return true;
 }
 
-void Interpreter::run_test(const Test& test) {
+bool Interpreter::run_test(const Test& test) {
 	log("Running test...");
 	/*Logger::activate();
 	const Regex& reg =
@@ -540,9 +544,10 @@ void Interpreter::run_test(const Test& test) {
 		Tester::test(get<Regex>(test.language), reg, test.iterations);
 	}*/
 	Logger::deactivate();
+	return true;
 }
 
-void Interpreter::run_operation(const GeneralOperation& op) {
+bool Interpreter::run_operation(const GeneralOperation& op) {
 	if (holds_alternative<Declaration>(op)) {
 		run_declaration(get<Declaration>(op));
 	} else if (holds_alternative<Predicate>(op)) {
@@ -550,6 +555,7 @@ void Interpreter::run_operation(const GeneralOperation& op) {
 	} else if (holds_alternative<Test>(op)) {
 		run_test(get<Test>(op));
 	}
+	return true;
 }
 
 int Interpreter::find_closing_par(const vector<Lexem>& lexems, size_t pos) {

--- a/libs/Interpreter/src/Interpreter.cpp
+++ b/libs/Interpreter/src/Interpreter.cpp
@@ -774,8 +774,13 @@ optional<Interpreter::Declaration> Interpreter::scan_declaration(
 	}
 	i++;
 
+	auto end = lexems.size();
+	if (lexems[end - 1].type == Lexem::doubleExclamation) {
+		end--;
+	}
+
 	// Expression
-	if (const auto& expr = scan_Expression(lexems, i, lexems.size());
+	if (const auto& expr = scan_Expression(lexems, i, end);
 		expr.has_value()) {
 		decl.expr = *expr;
 	} else {

--- a/libs/Interpreter/src/Interpreter.cpp
+++ b/libs/Interpreter/src/Interpreter.cpp
@@ -552,12 +552,25 @@ bool Interpreter::run_declaration(const Declaration& decl) {
 
 bool Interpreter::run_predicate(const Predicate& pred) {
 	log("Running predicate...");
-	/*Logger::activate();
-	auto res = apply_function(pred.predicate,
-							  parameters_to_arguments(pred.parameters));
-	log("    result: " + to_string(get<ObjectBoolean>(res).value));*/
+	Logger::activate();
+
+	FunctionSequence seq;
+	seq.functions = {pred.predicate};
+	seq.parameters = pred.arguments;
+
+	auto res = eval_function_sequence(seq);
+	bool success = false;
+
+	if (res.has_value() && holds_alternative<ObjectBoolean>(*res)) {
+		log("    result: " + to_string(get<ObjectBoolean>(*res).value));
+		success = true;
+	} else {
+		throw_error("while running predicate: invalid expression");
+		success = false;
+	}
+	
 	Logger::deactivate();
-	return true;
+	return success;
 }
 
 bool Interpreter::run_test(const Test& test) {

--- a/libs/Objects/include/Objects/Regex.h
+++ b/libs/Objects/include/Objects/Regex.h
@@ -16,26 +16,26 @@ class Language;
 class FiniteAutomaton;
 struct State;
 
-struct Lexem {
-	enum Type {
-		error,
-		parL, // (
-		parR, // )
-		alt,  // |
-		conc, // .
-		star, // *
-		symb, // alphabet symbol
-		eps,  // Epsilon
-	};
-
-	Type type = error;
-	alphabet_symbol symbol = "";
-	int number = 0;
-	Lexem(Type type = error, alphabet_symbol symbol = "", int number = 0);
-};
-
 class Regex : BaseObject {
   private:
+	struct Lexem {
+		enum Type {
+			error,
+			parL, // (
+			parR, // )
+			alt,  // |
+			conc, // .
+			star, // *
+			symb, // alphabet symbol
+			eps,  // Epsilon
+		};
+
+		Type type = error;
+		alphabet_symbol symbol = "";
+		int number = 0;
+		Lexem(Type type = error, alphabet_symbol symbol = "", int number = 0);
+	};
+
 	enum Type {
 		// Epsilon
 		eps,

--- a/libs/Objects/src/Regex.cpp
+++ b/libs/Objects/src/Regex.cpp
@@ -4,11 +4,11 @@
 #include "Objects/Logger.h"
 #include <set>
 
-Lexem::Lexem(Type type, alphabet_symbol symbol, int number)
+Regex::Lexem::Lexem(Type type, alphabet_symbol symbol, int number)
 	: type(type), symbol(symbol), number(number) {}
 
-vector<Lexem> Regex::parse_string(string str) {
-	vector<Lexem> lexems;
+vector<Regex::Lexem> Regex::parse_string(string str) {
+	vector<Regex::Lexem> lexems;
 	lexems = {};
 	bool flag_alt = false;
 	auto is_symbol = [](char c) {
@@ -18,30 +18,30 @@ vector<Lexem> Regex::parse_string(string str) {
 	// for (const char& c : str) {
 	for (size_t index = 0; index < str.size(); index++) {
 		char c = str[index];
-		Lexem lexem;
+		Regex::Lexem lexem;
 		switch (c) {
 		case '(':
-			lexem.type = Lexem::parL;
+			lexem.type = Regex::Lexem::parL;
 			flag_alt = true;
 			break;
 		case ')':
-			lexem.type = Lexem::parR;
-			if (lexems.back().type == Lexem::parL || flag_alt) {
-				lexem.type = Lexem::error;
+			lexem.type = Regex::Lexem::parR;
+			if (lexems.back().type == Regex::Lexem::parL || flag_alt) {
+				lexem.type = Regex::Lexem::error;
 				lexems = {};
 				lexems.push_back(lexem);
 				return lexems;
 			}
 			break;
 		case '|':
-			lexem.type = Lexem::alt;
+			lexem.type = Regex::Lexem::alt;
 			break;
 		case '*':
-			lexem.type = Lexem::star;
+			lexem.type = Regex::Lexem::star;
 			break;
 		default:
 			if (is_symbol(c)) {
-				lexem.type = Lexem::symb;
+				lexem.type = Regex::Lexem::symb;
 				string number;
 				for (size_t i = index + 1; i < str.size(); i++) {
 					if (str[i] >= '0' && str[i] <= '9') {
@@ -56,7 +56,7 @@ vector<Lexem> Regex::parse_string(string str) {
 				flag_alt = false;
 
 			} else {
-				lexem.type = Lexem::error;
+				lexem.type = Regex::Lexem::error;
 				lexems = {};
 				lexems.push_back(lexem);
 				return lexems;
@@ -66,69 +66,69 @@ vector<Lexem> Regex::parse_string(string str) {
 
 		if (lexems.size() &&
 			(
-				// Lexem left
-				lexems.back().type == Lexem::symb ||
-				lexems.back().type == Lexem::star ||
-				lexems.back().type == Lexem::parR) &&
+				// Regex::Lexem left
+				lexems.back().type == Regex::Lexem::symb ||
+				lexems.back().type == Regex::Lexem::star ||
+				lexems.back().type == Regex::Lexem::parR) &&
 			(
-				// Lexem right
-				lexem.type == Lexem::symb || lexem.type == Lexem::parL)) {
+				// Regex::Lexem right
+				lexem.type == Regex::Lexem::symb || lexem.type == Regex::Lexem::parL)) {
 
 			// We place . between
-			lexems.push_back({Lexem::conc});
+			lexems.push_back({Regex::Lexem::conc});
 		}
 
 		if (lexems.size() &&
-			((lexems.back().type == Lexem::parL &&
-			  (lexem.type == Lexem::parR || lexem.type == Lexem::alt)) ||
-			 (lexems.back().type == Lexem::alt && lexem.type == Lexem::parR) ||
-			 (lexems.back().type == Lexem::alt && lexem.type == Lexem::alt))) {
+			((lexems.back().type == Regex::Lexem::parL &&
+			  (lexem.type == Regex::Lexem::parR || lexem.type == Regex::Lexem::alt)) ||
+			 (lexems.back().type == Regex::Lexem::alt && lexem.type == Regex::Lexem::parR) ||
+			 (lexems.back().type == Regex::Lexem::alt && lexem.type == Regex::Lexem::alt))) {
 			//  We place eps between
-			lexems.push_back({Lexem::eps});
+			lexems.push_back({Regex::Lexem::eps});
 		}
 
 		lexems.push_back(lexem);
 	}
 
-	if (lexems.size() && lexems[0].type == Lexem::alt) {
-		lexems.insert(lexems.begin(), {Lexem::eps});
+	if (lexems.size() && lexems[0].type == Regex::Lexem::alt) {
+		lexems.insert(lexems.begin(), {Regex::Lexem::eps});
 	}
 
-	if (lexems.back().type == Lexem::alt) {
-		lexems.push_back({Lexem::eps});
+	if (lexems.back().type == Regex::Lexem::alt) {
+		lexems.push_back({Regex::Lexem::eps});
 	}
 
 	int balance = 0;
 	for (size_t i = 0; i < lexems.size(); i++) {
-		if (lexems[i].type == Lexem::parL) {
+		if (lexems[i].type == Regex::Lexem::parL) {
 			balance++;
 		}
-		if (lexems[i].type == Lexem::parR) {
+		if (lexems[i].type == Regex::Lexem::parR) {
 			balance--;
 		}
 	}
 
 	if (balance != 0) {
 		lexems = {};
-		lexems.push_back({Lexem::error});
+		lexems.push_back({Regex::Lexem::error});
 		return lexems;
 	}
 
 	return lexems;
 }
 
-Regex* Regex::scan_conc(const vector<Lexem>& lexems, int index_start,
+Regex* Regex::scan_conc(const vector<Regex::Lexem>& lexems, int index_start,
 						int index_end) {
 	Regex* p = nullptr;
 	int balance = 0;
 	for (int i = index_start; i < index_end; i++) {
-		if (lexems[i].type == Lexem::parL) { // LEFT_BRACKET
+		if (lexems[i].type == Regex::Lexem::parL) { // LEFT_BRACKET
 			balance++;
 		}
-		if (lexems[i].type == Lexem::parR) { // RIGHT_BRACKET
+		if (lexems[i].type == Regex::Lexem::parR) { // RIGHT_BRACKET
 			balance--;
 		}
-		if (lexems[i].type == Lexem::conc && balance == 0) {
+		if (lexems[i].type == Regex::Lexem::conc && balance == 0) {
 			Regex* l = expr(lexems, index_start, i);
 			Regex* r = expr(lexems, i + 1, index_end);
 
@@ -155,18 +155,18 @@ Regex* Regex::scan_conc(const vector<Lexem>& lexems, int index_start,
 	return nullptr;
 }
 
-Regex* Regex::scan_star(const vector<Lexem>& lexems, int index_start,
+Regex* Regex::scan_star(const vector<Regex::Lexem>& lexems, int index_start,
 						int index_end) {
 	Regex* p = nullptr;
 	int balance = 0;
 	for (int i = index_start; i < index_end; i++) {
-		if (lexems[i].type == Lexem::parL) { // LEFT_BRACKET
+		if (lexems[i].type == Regex::Lexem::parL) { // LEFT_BRACKET
 			balance++;
 		}
-		if (lexems[i].type == Lexem::parR) { // RIGHT_BRACKET
+		if (lexems[i].type == Regex::Lexem::parR) { // RIGHT_BRACKET
 			balance--;
 		}
-		if (lexems[i].type == Lexem::star && balance == 0) {
+		if (lexems[i].type == Regex::Lexem::star && balance == 0) {
 			Regex* l = expr(lexems, index_start, i);
 
 			if (l == nullptr || l->type == Regex::eps) {
@@ -189,18 +189,18 @@ Regex* Regex::scan_star(const vector<Lexem>& lexems, int index_start,
 	return nullptr;
 }
 
-Regex* Regex::scan_alt(const vector<Lexem>& lexems, int index_start,
+Regex* Regex::scan_alt(const vector<Regex::Lexem>& lexems, int index_start,
 					   int index_end) {
 	Regex* p = nullptr;
 	int balance = 0;
 	for (int i = index_start; i < index_end; i++) {
-		if (lexems[i].type == Lexem::parL) { // LEFT_BRACKET
+		if (lexems[i].type == Regex::Lexem::parL) { // LEFT_BRACKET
 			balance++;
 		}
-		if (lexems[i].type == Lexem::parR) { // RIGHT_BRACKET
+		if (lexems[i].type == Regex::Lexem::parR) { // RIGHT_BRACKET
 			balance--;
 		}
-		if (lexems[i].type == Lexem::alt && balance == 0) {
+		if (lexems[i].type == Regex::Lexem::alt && balance == 0) {
 			Regex* l = expr(lexems, index_start, i);
 			Regex* r = expr(lexems, i + 1, index_end);
 			// cout << l->type << " " << r->type << "\n";
@@ -229,11 +229,11 @@ Regex* Regex::scan_alt(const vector<Lexem>& lexems, int index_start,
 	return nullptr;
 }
 
-Regex* Regex::scan_symb(const vector<Lexem>& lexems, int index_start,
+Regex* Regex::scan_symb(const vector<Regex::Lexem>& lexems, int index_start,
 						int index_end) {
 	Regex* p = nullptr;
 	if ((lexems.size() <= index_start) ||
-		(lexems[index_start].type != Lexem::symb) ||
+		(lexems[index_start].type != Regex::Lexem::symb) ||
 		(index_end - index_start > 1)) {
 		return nullptr;
 	}
@@ -251,12 +251,12 @@ Regex* Regex::scan_symb(const vector<Lexem>& lexems, int index_start,
 	return p;
 }
 
-Regex* Regex::scan_eps(const vector<Lexem>& lexems, int index_start,
+Regex* Regex::scan_eps(const vector<Regex::Lexem>& lexems, int index_start,
 					   int index_end) {
 	Regex* p = nullptr;
 	// cout << lexems[index_start].type << "\n";
 	if (lexems.size() <= (index_start) ||
-		lexems[index_start].type != Lexem::eps) {
+		lexems[index_start].type != Regex::Lexem::eps) {
 		return nullptr;
 	}
 	p = new Regex;
@@ -272,19 +272,19 @@ Regex* Regex::scan_eps(const vector<Lexem>& lexems, int index_start,
 	return p;
 }
 
-Regex* Regex::scan_par(const vector<Lexem>& lexems, int index_start,
+Regex* Regex::scan_par(const vector<Regex::Lexem>& lexems, int index_start,
 					   int index_end) {
 	Regex* p = nullptr;
 
 	if (lexems.size() <= (index_end - 1) ||
-		(lexems[index_start].type != Lexem::parL ||
-		 lexems[index_end - 1].type != Lexem::parR)) {
+		(lexems[index_start].type != Regex::Lexem::parL ||
+		 lexems[index_end - 1].type != Regex::Lexem::parR)) {
 		return nullptr;
 	}
 	p = expr(lexems, index_start + 1, index_end - 1);
 	return p;
 }
-Regex* Regex::expr(const vector<Lexem>& lexems, int index_start,
+Regex* Regex::expr(const vector<Regex::Lexem>& lexems, int index_start,
 				   int index_end) {
 	Regex* p;
 	p = scan_alt(lexems, index_start, index_end);
@@ -338,7 +338,7 @@ bool Regex::from_string(string str) {
 		return false;
 	}
 
-	vector<Lexem> l = parse_string(str);
+	vector<Regex::Lexem> l = parse_string(str);
 	Regex* root = expr(l, 0, l.size());
 
 	if (root == nullptr || root->type == eps) {
@@ -802,9 +802,9 @@ int Regex::L() const {
 		return 0;
 	}
 }
-vector<Lexem>* Regex::first_state() const {
-	vector<Lexem>* l;
-	vector<Lexem>* r;
+vector<Regex::Lexem>* Regex::first_state() const {
+	vector<Regex::Lexem>* l;
+	vector<Regex::Lexem>* r;
 	switch (type) {
 	case Regex::alt:
 		l = term_l->first_state();
@@ -825,18 +825,18 @@ vector<Lexem>* Regex::first_state() const {
 		//
 		return l;
 	case Regex::eps:
-		l = new vector<Lexem>;
+		l = new vector<Regex::Lexem>;
 		return l;
 	default:
-		l = new vector<Lexem>;
+		l = new vector<Regex::Lexem>;
 		l->push_back(value);
 		return l;
 	}
 }
 
-vector<Lexem>* Regex::end_state() const {
-	vector<Lexem>* l;
-	vector<Lexem>* r;
+vector<Regex::Lexem>* Regex::end_state() const {
+	vector<Regex::Lexem>* l;
+	vector<Regex::Lexem>* r;
 	switch (type) {
 	case Regex::alt:
 		l = term_l->end_state();
@@ -857,10 +857,10 @@ vector<Lexem>* Regex::end_state() const {
 		}
 		return l;
 	case Regex::eps:
-		l = new vector<Lexem>;
+		l = new vector<Regex::Lexem>;
 		return l;
 	default:
-		l = new vector<Lexem>;
+		l = new vector<Regex::Lexem>;
 		l->push_back(value);
 		return l;
 	}
@@ -870,8 +870,8 @@ map<int, vector<int>> Regex::pairs() const {
 	map<int, vector<int>> l;
 	map<int, vector<int>> r;
 	map<int, vector<int>> p;
-	vector<Lexem>* rs;
-	vector<Lexem>* ps;
+	vector<Regex::Lexem>* rs;
+	vector<Regex::Lexem>* ps;
 	switch (type) {
 	case Regex::alt:
 		l = term_l->pairs();
@@ -945,7 +945,7 @@ vector<Regex*> Regex::pre_order_travers_vect() {
 	}
 	return r;
 }
-bool Regex::is_term(int number, const vector<Lexem>& list) const {
+bool Regex::is_term(int number, const vector<Regex::Lexem>& list) const {
 	for (size_t i = 0; i < list.size(); i++) {
 		if (list[i].number == number) {
 			return true;
@@ -986,8 +986,8 @@ FiniteAutomaton Regex::to_glushkov() const {
 	for (size_t i = 0; i < list.size(); i++) {
 		list[i]->value.number = i;
 	}
-	vector<Lexem>* first = test.first_state(); // Множество начальных состояний
-	vector<Lexem>* end = test.end_state(); // Множество конечных состояний
+	vector<Regex::Lexem>* first = test.first_state(); // Множество начальных состояний
+	vector<Regex::Lexem>* end = test.end_state(); // Множество конечных состояний
 	int eps_in = test.L();
 	map<int, vector<int>> p = test.pairs(); // Множество возможных пар состояний
 	vector<State> st; // Список состояний в автомате
@@ -1039,7 +1039,7 @@ FiniteAutomaton Regex::to_glushkov() const {
 	}
 
 	for (size_t i = 0; i < list.size(); i++) {
-		Lexem elem = list[i]->value;
+		Regex::Lexem elem = list[i]->value;
 		tr = {};
 
 		for (size_t j = 0; j < p[elem.number].size(); j++) {


### PR DESCRIPTION
## Версия 0.2 - баллистическая свинья
### Синтаксис регулярок
Регулярные выражения теперь надо обарачивать в фигурные скобки. Зато не путаются с идентификаторами
```
regex = {a|b*}
```
### Вложенные выражения
Переработан парсинг программы, теперь в качестве аргумента функции может быть поставлено любое выражение

```
A = Annote (Glushkov {a})
N1 = Glushkov {ab|a}
N2 =  Annote N1
Equiv N1 N2
Equiv ((N1)) ((Reverse.Reverse (N2)))
Test (Glushkov {a*}) {a*} 1
```
### Построчное исполнение
Есть возможность исполнять программу построчно, пригодится для **REPL**
```c++
interpreter.run_line("N1 = ((Glushkov ({ab|a})))")
interpreter.run_line("N2 =  (Annote N1)"
interpreter.run_line("Test (Glushkov {a*}) {a*} 1")
// и т.д.
```
В случае с файлом исполнение продолжается пока не будет достигнут конец файла или неисполнимая строка

### Улучшение логов
Более подробно логгируется работа интерпретатора. Логгер интерпретатора теперь считает уровень рекурсии, так что видно какая команда, какую запускала

Например:
```
running "A = Annote.Glushkov.DeAnnote {a}"
|  scanning
|  |  building function sequence
|
|  Running declaration...
|  |  evaluating function sequence
|  |  |  running function "DeAnnote"
|  |  |  function "DeAnnote" has left regex unchanged
|  |  |  running function "Glushkov"
|  |  |  running function "Annote"
|  |  |  function "Annote" has left automaton unchanged
|  |  function sequence evaluated
|  assigned to A
```



![изображение](https://user-images.githubusercontent.com/48261272/203158137-3b2a373a-a3d2-455f-9224-8569a9b35bd2.png)