### PR TITLE
Удалены предки

### DIFF
--- a/libs/Objects/include/Objects/FiniteAutomaton.h
+++ b/libs/Objects/include/Objects/FiniteAutomaton.h
@@ -27,7 +27,7 @@ struct State {
 	State();
 	State(int index, set<int> label, string identifier, bool is_terminal,
 		  map<alphabet_symbol, set<int>> transitions);
-	void set_transition(int, alphabet_symbol);
+	void set_transition(int, const alphabet_symbol&);
 };
 
 class FiniteAutomaton : public BaseObject {

--- a/libs/Objects/include/Objects/Language.h
+++ b/libs/Objects/include/Objects/Language.h
@@ -56,7 +56,7 @@ class Language {
 	int get_pump_length();
 	// минимальный дка
 	void set_min_dfa(int initial_state, const vector<State>& states,
-					 shared_ptr<Language>& Language);
+					 const shared_ptr<Language>& Language);
 	bool min_dfa_cached();
 	FiniteAutomaton get_min_dfa();
 	// синтаксический моноид
@@ -72,7 +72,7 @@ class Language {
 	void set_one_unambiguous_flag(bool);
 	bool get_one_unambiguous_flag();
 	bool is_one_unambiguous_regex_cached();
-	void set_one_unambiguous_regex(string, shared_ptr<Language>&);
+	void set_one_unambiguous_regex(string, const shared_ptr<Language>&);
 	Regex get_one_unambiguous_regex();
 	//  и тд
 };

--- a/libs/Objects/include/Objects/Regex.h
+++ b/libs/Objects/include/Objects/Regex.h
@@ -50,7 +50,6 @@ class Regex : BaseObject {
 	set<alphabet_symbol> alphabet;
 	Type type;
 	Lexem value;
-	Regex* term_p = nullptr;
 	Regex* term_l = nullptr;
 	Regex* term_r = nullptr;
 	// Turns string into lexem vector
@@ -87,11 +86,6 @@ class Regex : BaseObject {
 	bool is_term(int, const vector<Lexem>&)
 		const; // возвращает true, если состояние конечно
 	static bool equality_checker(const Regex*, const Regex*);
-	int search_replace_rec(
-		const Regex& replacing, const Regex& replaced_by,
-		Regex* original); //рекурсивный поиск заменяемого листа дерева
-	void normalize_this_regex(
-		const string& file); //переписывание regex по пользовательским правилам
 	string to_str_log() const;
 
 	// Рекурсивная генерация алфавита

--- a/libs/Objects/include/Objects/Regex.h
+++ b/libs/Objects/include/Objects/Regex.h
@@ -33,7 +33,7 @@ class Regex : BaseObject {
 		Type type = error;
 		alphabet_symbol symbol = "";
 		int number = 0;
-		Lexem(Type type = error, alphabet_symbol symbol = "", int number = 0);
+		Lexem(Type type = error, const alphabet_symbol& symbol = "", int number = 0);
 	};
 
 	enum Type {

--- a/libs/Objects/src/FiniteAutomaton.cpp
+++ b/libs/Objects/src/FiniteAutomaton.cpp
@@ -27,7 +27,7 @@ State::State(int index, set<int> label, string identifier, bool is_terminal,
 	: index(index), label(label), identifier(identifier),
 	  is_terminal(is_terminal), transitions(transitions) {}
 
-void State::set_transition(int to, alphabet_symbol symbol) {
+void State::set_transition(int to, const alphabet_symbol& symbol) {
 	transitions[symbol].insert(to);
 }
 

--- a/libs/Objects/src/Language.cpp
+++ b/libs/Objects/src/Language.cpp
@@ -36,7 +36,7 @@ int Language::get_pump_length() {
 }
 
 void Language::set_min_dfa(int initial_state, const vector<State>& states,
-						   shared_ptr<Language>& language) {
+						   const shared_ptr<Language>& language) {
 	min_dfa.emplace(FA_structure(initial_state, states, language));
 }
 
@@ -91,7 +91,7 @@ bool Language::is_one_unambiguous_regex_cached() {
 }
 
 void Language::set_one_unambiguous_regex(string str,
-										 shared_ptr<Language>& language) {
+										 const shared_ptr<Language>& language) {
 	one_unambiguous_regex.emplace(Regex_structure(str, language));
 }
 

--- a/libs/Objects/src/Regex.cpp
+++ b/libs/Objects/src/Regex.cpp
@@ -4,7 +4,7 @@
 #include "Objects/Logger.h"
 #include <set>
 
-Regex::Lexem::Lexem(Type type, alphabet_symbol symbol, int number)
+Regex::Lexem::Lexem(Type type, const alphabet_symbol& symbol, int number)
 	: type(type), symbol(symbol), number(number) {}
 
 vector<Regex::Lexem> Regex::parse_string(string str) {

--- a/libs/Objects/src/Regex.cpp
+++ b/libs/Objects/src/Regex.cpp
@@ -410,9 +410,7 @@ Regex* Regex::copy() const {
 	c->language = language;
 	if (type != Regex::eps && type != Regex::symb) {
 		c->term_l = term_l->copy();
-		if (type != Regex::star) {
-			c->term_r = term_r->copy();
-		}
+		if (type != Regex::star) c->term_r = term_r->copy();
 	}
 	return c;
 }
@@ -421,8 +419,7 @@ Regex::Regex(const Regex& reg)
 	: BaseObject(reg.language), type(reg.type), value(reg.value),
 	  alphabet(reg.alphabet),
 	  term_l(reg.term_l == nullptr ? nullptr : reg.term_l->copy()),
-	  term_r(reg.term_r == nullptr ? nullptr : reg.term_r->copy()) {
-}
+	  term_r(reg.term_r == nullptr ? nullptr : reg.term_r->copy()) {}
 
 Regex& Regex::operator=(const Regex& reg) {
 	clear();
@@ -430,12 +427,8 @@ Regex& Regex::operator=(const Regex& reg) {
 	type = reg.type;
 	value = reg.value;
 	alphabet = reg.alphabet;
-	if (reg.term_l) {
-		term_l = reg.term_l->copy();
-	}
-	if (reg.term_r) {
-		term_r = reg.term_r->copy();
-	}
+	if (reg.term_l) term_l = reg.term_l->copy();
+	if (reg.term_r) term_r = reg.term_r->copy();
 	return *this;
 }
 
@@ -1347,17 +1340,16 @@ bool Regex::derevative_with_respect_to_str(std::string str, const Regex* reg_e,
 	// cout << "start getting derevative for prefix " << str << " in "
 	//	 << reg_e->to_txt() << "\n";
 	for (int i = 0; i < str.size(); i++) {
-		auto sym = new Regex();
-		sym->type = Type::symb;
-		sym->value.symbol = str[i];
+		Regex sym;
+		sym.type = Type::symb;
+		sym.value.symbol = str[i];
 		next.clear();
-		success &= derevative_with_respect_to_sym(sym, &cur, next);
+		success &= derevative_with_respect_to_sym(&sym, &cur, next);
 		// cout << "derevative for prefix " << sym->to_txt() << " in "
 		//	 << cur.to_txt() << " is " << next.to_txt() << "\n";
 		if (!success) {
 			return false;
 		}
-		delete sym;
 		cur = next;
 	}
 	result = next;
@@ -1431,7 +1423,9 @@ int Regex::pump_length() const {
 					pumped_prefix += it->substr(0, j);
 					pumped_prefix += "(" + it->substr(j, k - j) + ")*";
 					pumped_prefix += it->substr(k, it->size() - k + j);
-					pumping.regex_union(new Regex(pumped_prefix), new Regex);
+					Regex a(pumped_prefix);
+					Regex b;
+					pumping.regex_union(&a, &b);
 					if (!derevative_with_respect_to_str(*it, this,
 														*pumping.term_r))
 						continue;

--- a/libs/Objects/src/Regex.cpp
+++ b/libs/Objects/src/Regex.cpp
@@ -142,8 +142,6 @@ Regex* Regex::scan_conc(const vector<Regex::Lexem>& lexems, int index_start,
 			}
 
 			p = new Regex;
-			l->term_p = p;
-			r->term_p = p;
 			p->term_l = l;
 			p->term_r = r;
 			p->value = lexems[i];
@@ -177,7 +175,6 @@ Regex* Regex::scan_star(const vector<Regex::Lexem>& lexems, int index_start,
 			}
 
 			p = new Regex;
-			l->term_p = p;
 			p->term_l = l;
 
 			p->term_r = nullptr;
@@ -214,8 +211,6 @@ Regex* Regex::scan_alt(const vector<Regex::Lexem>& lexems, int index_start,
 			}
 
 			p = new Regex;
-			l->term_p = p;
-			r->term_p = p;
 			p->term_l = l;
 			p->term_r = r;
 
@@ -344,8 +339,6 @@ Regex Regex::normalize_regex(const string& file) const {
 	Logger::init_step("Normalize");
 	Regex regex = *this;
 	Logger::log("Регулярное выражение до нормализации", regex.to_txt());
-	regex.normalize_this_regex(file);
-	Logger::log("Регулярное выражение после нормализации", regex.to_txt());
 	Logger::finish_step();
 	return regex;
 }
@@ -369,11 +362,9 @@ bool Regex::from_string(const string& str) {
 	language = make_shared<Language>(alphabet);
 	if (root->term_l != nullptr) {
 		term_l = root->term_l->copy();
-		term_l->term_p = this;
 	}
 	if (root->term_r != nullptr) {
 		term_r = root->term_r->copy();
-		term_r->term_p = this;
 	}
 	delete root;
 	return true;
@@ -419,10 +410,8 @@ Regex* Regex::copy() const {
 	c->language = language;
 	if (type != Regex::eps && type != Regex::symb) {
 		c->term_l = term_l->copy();
-		c->term_l->term_p = c;
 		if (type != Regex::star) {
 			c->term_r = term_r->copy();
-			c->term_r->term_p = c;
 		}
 	}
 	return c;
@@ -430,11 +419,9 @@ Regex* Regex::copy() const {
 
 Regex::Regex(const Regex& reg)
 	: BaseObject(reg.language), type(reg.type), value(reg.value),
-	  term_p(nullptr), alphabet(reg.alphabet),
+	  alphabet(reg.alphabet),
 	  term_l(reg.term_l == nullptr ? nullptr : reg.term_l->copy()),
 	  term_r(reg.term_r == nullptr ? nullptr : reg.term_r->copy()) {
-	if (term_l) term_l->term_p = this;
-	if (term_r) term_r->term_p = this;
 }
 
 Regex& Regex::operator=(const Regex& reg) {
@@ -445,11 +432,9 @@ Regex& Regex::operator=(const Regex& reg) {
 	alphabet = reg.alphabet;
 	if (reg.term_l) {
 		term_l = reg.term_l->copy();
-		term_l->term_p = this;
 	}
 	if (reg.term_r) {
 		term_r = reg.term_r->copy();
-		term_r->term_p = this;
 	}
 	return *this;
 }
@@ -476,84 +461,6 @@ void Regex::set_language(const set<alphabet_symbol>& _alphabet) {
 	language = make_shared<Language>(alphabet);
 }
 
-int Regex::search_replace_rec(const Regex& replacing, const Regex& replaced_by,
-							  Regex* original) {
-	int cond = 0;
-	if (equal(replacing, *original)) {
-		Regex* temp = new Regex(replaced_by);
-		cond++;
-		if (original->term_p && original->term_p->term_l &&
-			original->term_p->term_l == original) {
-			temp->term_p = original->term_p;
-			original->term_p->term_l = temp;
-		} else {
-			if (original->term_p && original->term_p->term_r &&
-				original->term_p->term_r == original) {
-				temp->term_p = original->term_p;
-				original->term_p->term_r = temp;
-			}
-		}
-		delete original;
-	} else {
-		if (original->term_l) {
-			cond +=
-				search_replace_rec(replacing, replaced_by, original->term_l);
-		}
-		if (original->term_r) {
-			cond +=
-				search_replace_rec(replacing, replaced_by, original->term_r);
-		}
-	}
-	return cond;
-	//Привычка зарубать себе на носу довела Буратино до самоампутации органа
-	//обоняния.
-}
-void Regex::normalize_this_regex(const string& file) {
-	struct Rules {
-		Regex from;
-		Regex to;
-	};
-	vector<Rules> all_rules;
-	string line;
-	std::ifstream in(file);
-	if (in.is_open()) {
-		while (getline(in, line)) {
-			string v1, v2;
-			int ind = -1;
-			for (char c : line) {
-				if (c == '=') {
-					ind = v1.size();
-					continue;
-				}
-				if (c != ' ') {
-					if (ind == -1) {
-						v1 += c;
-					} else {
-						v2 += c;
-					}
-				}
-			}
-			if (v1 == "" || v2 == "") {
-				cout << "error rewriting rules read from file";
-				return;
-			}
-			Regex a(v1);
-			Regex b(v2);
-
-			Rules temp = {a, b};
-			all_rules.push_back(temp);
-		}
-	}
-	in.close();
-	for (int i = 0; i < all_rules.size(); i++) {
-		int cond = 0;
-		cond += search_replace_rec(all_rules[i].from, all_rules[i].to, this);
-		if (cond != 0) {
-			i--;
-		}
-	}
-}
-
 void Regex::pre_order_travers() const {
 	if (type == Regex::symb /*&& value.symbol*/) {
 		cout << value.symbol << " ";
@@ -577,16 +484,17 @@ string Regex::to_txt() const {
 		str2 = term_r->to_txt();
 	}
 	string symb;
-	if (type == Type::symb /*value.symbol*/) symb = value.symbol;
-	if (type == Type::eps) symb = "";
-	if (type == Type::alt) {
-		symb = '|';
-		if (term_p != nullptr && term_p->type == Type::conc) {
-			str1 = "(" + str1;
-			str2 = str2 + ")"; // ставим скобки при альтернативах внутри
-							   // конкатенации a(a|b)a
+	if (type == Type::conc) {
+		if (term_l && term_l->type == Type::alt) {
+			str1 = "(" + str1 + ")";
+		}
+		if (term_r && term_r->type == Type::alt) {
+			str2 = "(" + str2 + ")";
 		}
 	}
+	if (type == Type::symb /*value.symbol*/) symb = value.symbol;
+	if (type == Type::eps) symb = "";
+	if (type == Type::alt) symb = '|';
 	if (type == Type::star) {
 		symb = '*';
 		if (term_l->type != Type::symb)
@@ -1703,17 +1611,18 @@ string Regex::to_str_log() const {
 		str2 = term_r->to_str_log();
 	}
 	string symb;
+	if (type == Type::conc) {
+		if (term_l && term_l->type == Type::alt) {
+			str1 = "(" + str1 + ")";
+		}
+		if (term_r && term_r->type == Type::alt) {
+			str2 = "(" + str2 + ")";
+		}
+	}
 	if (type == Type::symb /*value.symbol*/)
 		symb = value.symbol + to_string(value.number + 1);
 	if (type == Type::eps) symb = "";
-	if (type == Type::alt) {
-		symb = '|';
-		if (term_p != nullptr && term_p->type == Type::conc) {
-			str1 = "(" + str1;
-			str2 = str2 + ")"; // ставим скобки при альтернативах внутри
-							   // конкатенации a(a|b)a
-		}
-	}
+	if (type == Type::alt) symb = '|';
 	if (type == Type::star) {
 		symb = '*';
 		if (term_l->type != Type::symb)


### PR DESCRIPTION
Были убраны предки регулярных выражений, они усложняли работу с regex и использовались всего в паре функций.